### PR TITLE
Fix drawing of WT efficiency slices

### DIFF
--- a/plotEff.cc
+++ b/plotEff.cc
@@ -114,7 +114,7 @@ void plotEffBin(int q2Bin, int parity, bool doClosure, int year)
   }
   
   // import KDE efficiency histograms
-  string filename = Form((parity==0?"files/KDEeff_b%i_ev_%i_recoFrac.root":"files/KDEeff_b%i_od_%i_recoFrac.root"),q2Bin, year);
+  string filename = Form((parity==0?"files/KDEeff_b%i_ev_%i.root":"files/KDEeff_b%i_od_%i.root"),q2Bin, year);
   TFile* fin = new TFile( filename.c_str(), "READ" );
   if ( !fin || !fin->IsOpen() ) {
     cout<<"File not found: "<<filename<<endl;
@@ -293,15 +293,13 @@ void plotEffBin(int q2Bin, int parity, bool doClosure, int year)
 
 
         TH1D* ctDist_corr = (TH1D*)ctGENNumDist_corr[ivar]->Clone(Form("ctDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        ctDist->Divide(ctGENDenDist_corr[ivar]);
+        ctDist_corr->Divide(ctGENDenDist_corr[ivar]);
         ctDist_corr->Divide(ctDenDist_corr[ivar]);
         effCDist_corr[ivar] = (TH1D*)ctDist_corr->Clone(Form("effCDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
         if (doCT) effCDist_corr[ivar]->Multiply(ctRECODist_corr[ivar]);
 
         TH1D* wtDist_corr = (TH1D*)wtGENNumDist_corr[ivar]->Clone(Form("wtDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-//      // sara!! plot only the second fraction
-//       wtDist->Divide(wtGENDenDist_corr[ivar]);
-        wtDist_corr->Divide(wtGENNumDist_corr[ivar]);
+        wtDist_corr->Divide(wtGENDenDist_corr[ivar]);
         wtDist_corr->Divide(wtDenDist_corr[ivar]);
         effWDist_corr[ivar] = Invert1Dhist(wtDist_corr,Form("effWDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
         if (doWT) effWDist_corr[ivar]->Multiply(wtRECODist_corr[ivar]);

--- a/plotEff.cc
+++ b/plotEff.cc
@@ -279,30 +279,36 @@ void plotEffBin(int q2Bin, int parity, bool doClosure, int year)
       
       // composing binned efficiencies from sliced distributions
       for (int ivar=0; ivar< 3; ivar++){
-        TH1D* ctDist = (TH1D*)ctGENNumDist[ivar]->Clone(Form("ctDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        ctDist->Divide(ctGENDenDist[ivar]);
-        ctDist->Divide(ctDenDist[ivar]);
-        effCDist[ivar] = (TH1D*)ctDist->Clone(Form("effCDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        if (doCT) effCDist[ivar]->Multiply(ctRECODist[ivar]);
+	if (doCT) {
+	  effCDist[ivar] = (TH1D*)ctGENNumDist[ivar]->Clone(Form("effCDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
+	  effCDist[ivar]->Divide(ctGENDenDist[ivar]);
+	  effCDist[ivar]->Divide(ctDenDist[ivar]);
+	  effCDist[ivar]->Multiply(ctRECODist[ivar]);
+	}
       
-        TH1D* wtDist = (TH1D*)wtGENNumDist[ivar]->Clone(Form("wtDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        wtDist->Divide(wtGENDenDist[ivar]);
-        wtDist->Divide(wtDenDist[ivar]);
-        effWDist[ivar] = Invert1Dhist(wtDist,Form("effWDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        if (doWT) effWDist[ivar]->Multiply(wtRECODist[ivar]);
+	if (doWT) {
+	  TH1D* wtDist = (TH1D*)wtGENNumDist[ivar]->Clone(Form("wtDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
+	  wtDist->Divide(wtGENDenDist[ivar]);
+	  wtDist->Divide(wtDenDist[ivar]);
+	  effWDist[ivar] = Invert1Dhist(wtDist,Form("effWDist%s_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
+	  effWDist[ivar]->Multiply(wtRECODist[ivar]);
+	}
 
 
-        TH1D* ctDist_corr = (TH1D*)ctGENNumDist_corr[ivar]->Clone(Form("ctDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        ctDist_corr->Divide(ctGENDenDist_corr[ivar]);
-        ctDist_corr->Divide(ctDenDist_corr[ivar]);
-        effCDist_corr[ivar] = (TH1D*)ctDist_corr->Clone(Form("effCDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        if (doCT) effCDist_corr[ivar]->Multiply(ctRECODist_corr[ivar]);
+	if (doCT) {
+	  effCDist_corr[ivar] = (TH1D*)ctGENNumDist_corr[ivar]->Clone(Form("effCDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
+	  effCDist_corr[ivar]->Divide(ctGENDenDist_corr[ivar]);
+	  effCDist_corr[ivar]->Divide(ctDenDist_corr[ivar]);
+	  effCDist_corr[ivar]->Multiply(ctRECODist_corr[ivar]);
+	}
 
-        TH1D* wtDist_corr = (TH1D*)wtGENNumDist_corr[ivar]->Clone(Form("wtDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        wtDist_corr->Divide(wtGENDenDist_corr[ivar]);
-        wtDist_corr->Divide(wtDenDist_corr[ivar]);
-        effWDist_corr[ivar] = Invert1Dhist(wtDist_corr,Form("effWDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
-        if (doWT) effWDist_corr[ivar]->Multiply(wtRECODist_corr[ivar]);
+	if (doWT) {
+	  TH1D* wtDist_corr = (TH1D*)wtGENNumDist_corr[ivar]->Clone(Form("wtDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
+	  wtDist_corr->Divide(wtGENDenDist_corr[ivar]);
+	  wtDist_corr->Divide(wtDenDist_corr[ivar]);
+	  effWDist_corr[ivar] = Invert1Dhist(wtDist_corr,Form("effWDist%s_corr_%i_%i_%s",varCoord[ivar],i,j,shortString.c_str()));
+	  effWDist_corr[ivar]->Multiply(wtRECODist_corr[ivar]);
+	}
       }
 
       // set histo properties

--- a/plotEff.sh
+++ b/plotEff.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 par=1
-closure=0
+closure=1
 year=2016
 
 # Create directories for logs and plots

--- a/plotEff.sh
+++ b/plotEff.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 par=1
-closure=1
+closure=0
 year=2016
 
 # Create directories for logs and plots


### PR DESCRIPTION
This PR fixes the slicing procedure for WT GEN fraction and RECO denominator, using the inverted-sign angular variables to select the slice window.
In addition, some changes to the code are made to make it more compact.
[can be further improved]
So maybe it's not straightforward to compare to the original version. Basically the fix is contained in [these](https://github.com/CMSKStarMuMu/eff-KDE/blob/fix-plotEff/plotEff.cc#L189-L193) and [these](https://github.com/CMSKStarMuMu/eff-KDE/blob/fix-plotEff/plotEff.cc#L247-L272) lines.